### PR TITLE
Add basic FastAPI financial management app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+finance.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-Gestão Financeira
+# Gestão Financeira
+
+Aplicativo simples com FastAPI para gerenciar contas, categorias e transações financeiras, permitindo separar despesas pessoais e empresariais.
+
+## Requisitos
+
+Instale as dependências:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Executando testes
+
+```bash
+pytest
+```

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,12 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./finance.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,46 @@
+from fastapi import Depends, FastAPI
+from sqlalchemy.orm import Session
+
+from . import models, schemas
+from .database import SessionLocal, engine
+
+models.Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.post("/accounts/", response_model=schemas.Account)
+def create_account(account: schemas.AccountCreate, db: Session = Depends(get_db)):
+    db_account = models.Account(**account.dict())
+    db.add(db_account)
+    db.commit()
+    db.refresh(db_account)
+    return db_account
+
+
+@app.post("/categories/", response_model=schemas.Category)
+def create_category(category: schemas.CategoryCreate, db: Session = Depends(get_db)):
+    db_category = models.Category(**category.dict())
+    db.add(db_category)
+    db.commit()
+    db.refresh(db_category)
+    return db_category
+
+
+@app.post("/transactions/", response_model=schemas.Transaction)
+def create_transaction(
+    transaction: schemas.TransactionCreate, db: Session = Depends(get_db)
+):
+    db_transaction = models.Transaction(**transaction.dict())
+    db.add(db_transaction)
+    db.commit()
+    db.refresh(db_transaction)
+    return db_transaction

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+import enum
+from sqlalchemy import Column, DateTime, Enum, Float, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+
+class AccountType(str, enum.Enum):
+    personal = "personal"
+    company = "company"
+
+
+class CategoryType(str, enum.Enum):
+    income = "income"
+    expense = "expense"
+
+
+class Account(Base):
+    __tablename__ = "accounts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, nullable=False)
+    type = Column(Enum(AccountType), nullable=False)
+    balance = Column(Float, default=0)
+
+    transactions = relationship(
+        "Transaction",
+        back_populates="account_origin",
+        foreign_keys="Transaction.account_origin_id",
+    )
+
+
+class Category(Base):
+    __tablename__ = "categories"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, nullable=False)
+    type = Column(Enum(CategoryType), nullable=False)
+
+
+class Transaction(Base):
+    __tablename__ = "transactions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    amount = Column(Float, nullable=False)
+    date = Column(DateTime, default=datetime.utcnow)
+    description = Column(String, nullable=True)
+    category_id = Column(Integer, ForeignKey("categories.id"))
+    account_origin_id = Column(Integer, ForeignKey("accounts.id"))
+    account_dest_id = Column(Integer, ForeignKey("accounts.id"), nullable=True)
+
+    category = relationship("Category")
+    account_origin = relationship(
+        "Account", foreign_keys=[account_origin_id], back_populates="transactions"
+    )
+    account_dest = relationship("Account", foreign_keys=[account_dest_id])

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class AccountBase(BaseModel):
+    name: str
+    type: str
+    balance: float = 0
+
+
+class AccountCreate(AccountBase):
+    pass
+
+
+class Account(AccountBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class CategoryBase(BaseModel):
+    name: str
+    type: str
+
+
+class CategoryCreate(CategoryBase):
+    pass
+
+
+class Category(CategoryBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class TransactionBase(BaseModel):
+    amount: float
+    description: Optional[str] = None
+    category_id: int
+    account_origin_id: int
+    account_dest_id: Optional[int] = None
+    date: Optional[datetime] = None
+
+
+class TransactionCreate(TransactionBase):
+    pass
+
+
+class Transaction(TransactionBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic
+pytest

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,54 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_create_account():
+    response = client.post(
+        "/accounts/",
+        json={"name": "Conta Pessoal", "type": "personal", "balance": 100},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Conta Pessoal"
+    assert data["type"] == "personal"
+    assert data["balance"] == 100
+
+
+def test_create_category():
+    response = client.post(
+        "/categories/",
+        json={"name": "Aluguel", "type": "expense"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Aluguel"
+    assert data["type"] == "expense"
+
+
+def test_create_transaction():
+    # ensure account and category exist
+    client.post(
+        "/accounts/",
+        json={"name": "Conta Empresa", "type": "company", "balance": 0},
+    )
+    client.post(
+        "/categories/",
+        json={"name": "Venda", "type": "income"},
+    )
+    response = client.post(
+        "/transactions/",
+        json={
+            "amount": 500,
+            "description": "Venda de produto",
+            "category_id": 2,
+            "account_origin_id": 2,
+            "account_dest_id": None,
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["amount"] == 500
+    assert data["description"] == "Venda de produto"


### PR DESCRIPTION
## Summary
- scaffold FastAPI application with accounts, categories, and transactions
- add SQLAlchemy models and pydantic schemas
- include tests for account, category, and transaction creation

## Testing
- `python -m pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement fastapi)
- `pytest` (fails: ModuleNotFoundError: No module named 'fastapi')

------
https://chatgpt.com/codex/tasks/task_e_68bcc0ee67d0832093dca3d5f3a978e6